### PR TITLE
Convert string to camel case

### DIFF
--- a/Training/Program.cs
+++ b/Training/Program.cs
@@ -4,7 +4,12 @@
     {
         private static void Main(string[] args)
         {
+            Console.WriteLine(ToCamelCase("hello"));
+        }
 
+        private static string ToCamelCase(string str)
+        {
+            return string.Concat(str.Split('-', '_').Select((s, i) => i > 0 ? char.ToUpper(s[0]) + s.Substring(1) : s));
         }
 
         public static int Persistence(long num)


### PR DESCRIPTION
Complete the method/function so that it converts dash/underscore delimited words into [camel casing]. The first word within the output should be capitalized only if the original word was capitalized (known as Upper Camel Case, also often referred to as Pascal case). The next words should be always capitalized.

Examples
"the-stealth-warrior" gets converted to "theStealthWarrior"
"The_Stealth_Warrior" gets converted to "TheStealthWarrior"