### PR TITLE
Regex validate PIN code + tests

### DIFF
--- a/Training.Tests/KataTests.cs
+++ b/Training.Tests/KataTests.cs
@@ -6,6 +6,41 @@ namespace Training.Tests
     public class KataTests
     {
         [Fact]
+        public void ValidatePinLengthTest()
+        {
+            Assert.False(Kata.ValidatePin("1"));
+            Assert.False(Kata.ValidatePin("12"));
+            Assert.False(Kata.ValidatePin("123"));
+            Assert.False(Kata.ValidatePin("12345"));
+            Assert.False(Kata.ValidatePin("1234567"));
+            Assert.False(Kata.ValidatePin("-1234"));
+            Assert.False(Kata.ValidatePin("-12345"));
+            Assert.False(Kata.ValidatePin("1.234"));
+            Assert.False(Kata.ValidatePin("-1.234"));
+            Assert.False(Kata.ValidatePin("00000000"));
+        }
+
+        [Fact]
+        public void ValidatePinNonDigitTest()
+        {
+            Assert.False(Kata.ValidatePin("a234"));
+            Assert.False(Kata.ValidatePin(".234"));
+        }
+
+        [Fact]
+        public void ValidatePinValidTest()
+        {
+            Assert.True(Kata.ValidatePin("0000"));
+            Assert.True(Kata.ValidatePin("1234"));
+            Assert.True(Kata.ValidatePin("1111"));
+            Assert.True(Kata.ValidatePin("123456"));
+            Assert.True(Kata.ValidatePin("098765"));
+            Assert.True(Kata.ValidatePin("000000"));
+            Assert.True(Kata.ValidatePin("090909"));
+        }
+
+
+        [Fact]
         public void MoveZeroesSampleTest()
         {
             Assert.Equal(new int[] { 1, 2, 1, 1, 3, 1, 0, 0, 0, 0 }, Kata.MoveZeroes(new int[] { 1, 2, 0, 1, 0, 1, 0, 3, 0, 1 }));

--- a/Training/Classes/Kata.cs
+++ b/Training/Classes/Kata.cs
@@ -1,7 +1,15 @@
-﻿namespace Training.Classes
+﻿using System.Text.RegularExpressions;
+
+namespace Training.Classes
 {
     public class Kata
     {
+        public static bool ValidatePin(string pin)
+        {
+            string result = Regex.Match(pin, @"\d+").Value;
+            return pin == result && (result.Length == 4 || result.Length == 6);
+        }
+
         public static int DescendingOrder(int num)
         {
             return int.Parse(string.Concat(num.ToString()


### PR DESCRIPTION
ATM machines allow 4 or 6 digit PIN codes and PIN codes cannot contain anything but exactly 4 digits or exactly 6 digits.

If the function is passed a valid PIN string, return true, else return false.

Examples (Input --> Output)
"1234"   -->  true
"12345"  -->  false
"a234"   -->  false